### PR TITLE
Improve XL armor need calculation with a recursive check on copy-from, abstract support, blacklist keywords

### DIFF
--- a/DEV_TOOLS/XL_ARMORS_GENERATOR/armors_blacklist.txt
+++ b/DEV_TOOLS/XL_ARMORS_GENERATOR/armors_blacklist.txt
@@ -34,6 +34,7 @@ chainmail_vest
 chestguard_hard
 chestrig
 conductive_suit
+crt_canteen
 cuirass_lightplate
 duffelbag
 duster


### PR DESCRIPTION
- blacklist keywords (in addition to the blacklist file). Although not really needed with the additions below, but still, it's here
- if an armor could still have a XL armor and uses copy-from, recursive check on this copy-from until we find the highest node in the tree (the last parent)
  - linked to this change, add support for abstract armor objects (and recursive check on copy-form too)
- remove ids that ends with "_on" (objects in active state). They were cluttering the UI for nothing
- refactorise a bit